### PR TITLE
params middleware - default options

### DIFF
--- a/packages/redux-api-params-middleware/README.md
+++ b/packages/redux-api-params-middleware/README.md
@@ -16,9 +16,11 @@ Then, to enable paramsMiddleware, use [`applyMiddleware`](https://redux.js.org/a
 import { applyMiddleware, createStore } from 'redux';
 
 import { apiMiddleware } from 'redux-api-middleware';
-import paramsMiddleware from '@tshio/redux-api-params-middleware';
+import createParamsMiddleware from '@tshio/redux-api-params-middleware';
 
 import { appReducer } from 'app/app.reducer';
+
+const paramsMiddleware = createParamsMiddleware();
 
 const middlewares = [paramsMiddleware, apiMiddleware];
 
@@ -48,11 +50,32 @@ export const fetchUsers = () => ({
 
 ## Params format
 
-We can change our params format by using `paramsOptions`.
-
 Default params format is _**indices**_.
 
-We are using stringify from [qs](https://github.com/ljharb/qs) so we can pass any options from documentation as paramOptions.
+We are using stringify from [qs](https://github.com/ljharb/qs) so we can pass any options from documentation
+as `defaultOptions` or `paramOptions`.
+
+### Globally
+
+You can change params format by using `defaultOptions` option during creation of the middleware:
+
+```js
+const paramsMiddleware = createParamsMiddleware({
+  defaultOptions: {
+    arrayFormat: 'repeat',
+  },
+});
+
+// output 'a=b&a=c'
+```
+
+Such middleware configuration will use 'repeat' format unless some `paramOptions` are defined for particular action.
+
+### In particular request
+
+In case you want to override params format for particular request only
+(for instance when you use multiple APIs with inconsistent format)
+you can change params format by using `paramsOptions` in particular action.
 
 ```js
 params: {
@@ -62,7 +85,7 @@ paramsOptions: {
     arrayFormat: 'indices'
 }
 
-//  output'a[0]=b&a[1]=c'
+//  output 'a[0]=b&a[1]=c'
 ```
 
 ```
@@ -79,7 +102,7 @@ params: {
     a: ['b', 'c'],
 }
 paramsOptions: {
-    arrayFormat: 'repeat' // output'a=b&a=c'
+    arrayFormat: 'repeat' // output 'a=b&a=c'
 }
 ```
 

--- a/packages/redux-api-params-middleware/src/__tests__/middleware.spec.js
+++ b/packages/redux-api-params-middleware/src/__tests__/middleware.spec.js
@@ -1,10 +1,11 @@
 import { RSAA } from 'redux-api-middleware';
 
-import paramsMiddleware from '../middleware';
+import createParamsMiddleware from '../middleware';
 
 describe('Params middleware', () => {
   test('handles only RSAA', () => {
     const next = jest.fn();
+    const paramsMiddleware = createParamsMiddleware();
 
     paramsMiddleware()(next)({
       type: 'FOO',
@@ -17,6 +18,7 @@ describe('Params middleware', () => {
 
   test('handles only RSAA with params', () => {
     const next = jest.fn();
+    const paramsMiddleware = createParamsMiddleware();
 
     paramsMiddleware()(next)({
       [RSAA]: {
@@ -37,6 +39,7 @@ describe('Params middleware', () => {
   test('handles only RSAA with endpoints as string', () => {
     const next = jest.fn();
 
+    const paramsMiddleware = createParamsMiddleware();
     const endpoint = () => '/foo';
 
     paramsMiddleware()(next)({
@@ -55,6 +58,7 @@ describe('Params middleware', () => {
 
   test('parametrises endpoint correctly', () => {
     const next = jest.fn();
+    const paramsMiddleware = createParamsMiddleware();
 
     paramsMiddleware()(next)({
       [RSAA]: {
@@ -81,6 +85,7 @@ describe('Params middleware', () => {
 
   test('parametrises endpoint correctly using stringify options - array format changed', () => {
     const next = jest.fn();
+    const paramsMiddleware = createParamsMiddleware();
 
     paramsMiddleware()(next)({
       [RSAA]: {
@@ -110,6 +115,7 @@ describe('Params middleware', () => {
 
   test('parametrises endpoint correctly using stringify options - indices disabled', () => {
     const next = jest.fn();
+    const paramsMiddleware = createParamsMiddleware();
 
     paramsMiddleware()(next)({
       [RSAA]: {
@@ -139,6 +145,7 @@ describe('Params middleware', () => {
 
   test('overrides parameters from endpoint', () => {
     const next = jest.fn();
+    const paramsMiddleware = createParamsMiddleware();
 
     paramsMiddleware()(next)({
       [RSAA]: {
@@ -155,6 +162,37 @@ describe('Params middleware', () => {
       [RSAA]: expect.objectContaining({
         foo: 'bar',
         endpoint: '/foo?foo=baz',
+      }),
+    });
+  });
+
+  test('uses custom default stringify options', () => {
+    const next = jest.fn();
+    const paramsMiddleware = createParamsMiddleware({
+      defaultOptions: {
+        arrayFormat: 'brackets',
+      },
+    });
+
+    paramsMiddleware()(next)({
+      [RSAA]: {
+        foo: 'bar',
+        endpoint: '/foo?foo=bar',
+        types: ['REQUEST', 'SUCCESS', 'FAILURE'],
+        params: {
+          bar: ['baz', 'qaz'],
+          baz: null,
+          qux: undefined,
+          quux: 0,
+          quuz: false,
+        },
+      },
+    });
+
+    expect(next).toHaveBeenCalledWith({
+      [RSAA]: expect.objectContaining({
+        foo: 'bar',
+        endpoint: '/foo?foo=bar&bar%5B%5D=baz&bar%5B%5D=qaz&baz=&quux=0&quuz=false',
       }),
     });
   });

--- a/packages/redux-api-params-middleware/src/middleware.js
+++ b/packages/redux-api-params-middleware/src/middleware.js
@@ -5,8 +5,10 @@ import { parse, stringify } from 'qs';
 
 import type { Dispatch } from 'redux';
 import type { Action } from './types';
+import type { StringifyOptions } from 'qs';
+import type { Options } from './middleware.types';
 
-function parametriseEndpoint(endpoint, params, options = { arrayFormat: 'indices' }) {
+function parametriseEndpoint(endpoint, params, options: StringifyOptions) {
   const [pure, query = ''] = endpoint.split('?');
 
   return (
@@ -22,21 +24,25 @@ function parametriseEndpoint(endpoint, params, options = { arrayFormat: 'indices
   );
 }
 
-export default function paramsMiddleware() {
-  return (next: Dispatch<Action>) => (action: Action) => {
-    const apiCall = action[RSAA];
+export default function paramsMiddlewareFactory(options?: Options = { defaultOptions: { arrayFormat: 'indices' } }) {
+  function paramsMiddleware() {
+    return (next: Dispatch<Action>) => (action: Action) => {
+      const apiCall = action[RSAA];
 
-    if (!apiCall || !apiCall.params || typeof apiCall.endpoint === 'function') {
-      return next(action);
-    }
+      if (!apiCall || !apiCall.params || typeof apiCall.endpoint === 'function') {
+        return next(action);
+      }
 
-    const { endpoint, params, paramsOptions, ...rest } = apiCall;
+      const { endpoint, params, paramsOptions, ...rest } = apiCall;
 
-    return next({
-      [RSAA]: {
-        ...rest,
-        endpoint: parametriseEndpoint(endpoint, params, paramsOptions),
-      },
-    });
-  };
+      return next({
+        [RSAA]: {
+          ...rest,
+          endpoint: parametriseEndpoint(endpoint, params, paramsOptions || options.defaultOptions),
+        },
+      });
+    };
+  }
+
+  return paramsMiddleware;
 }

--- a/packages/redux-api-params-middleware/src/middleware.types.js.flow
+++ b/packages/redux-api-params-middleware/src/middleware.types.js.flow
@@ -1,0 +1,8 @@
+// @flow
+
+import type { StringifyOptions } from 'qs';
+
+
+export type Options = {
+  defaultOptions: StringifyOptions
+};


### PR DESCRIPTION
Breaking change for params middleware. I've changed params-middleware to factory function to enable configuration of default stringify options (used globally when no paramOptions provided in RSAA action).