### PR TITLE
Adjust redux-api-auth-middleware to standard oAuth response

### DIFF
--- a/packages/redux-api-auth-middleware/.gitignore
+++ b/packages/redux-api-auth-middleware/.gitignore
@@ -1,3 +1,3 @@
 es
 /*.js
-store
+/store

--- a/packages/redux-api-auth-middleware/README.md
+++ b/packages/redux-api-auth-middleware/README.md
@@ -59,14 +59,14 @@ export default combineReducers({
 
 ## Usage
 
-To use this middleware you have to save your `authToken` and `refreshToken` using `setTokenAction`.
+To use this middleware you have to save your `accessToken` and `refreshToken` using `setTokenAction`.
 
 ```js
 import { setTokenAction } from '@tshio/redux-api-auth-middleware';
 import Component from './component';
 
 const mapDispatchToProps = dispatch => ({
-  onSignIn: ({authToken, refreshToken}) => dispatch(setTokenAction({ auth_token: authToken, refresh_token: refreshToken, expires_in: 1555055916 }));
+  onSignIn: ({accessToken, refreshToken}) => dispatch(setTokenAction({ access_token: accessToken, refresh_token: refreshToken, expires_in: 1555055916 }));
 }
 
 export default connect(
@@ -144,13 +144,13 @@ There are two built in functions for calculating token expiration timestamp, one
 
 #### JWT Example
 
-Function takes payload below, parses the `auth_token` and looks for `iat` and `exp` keys to sum them. If they are not there it returns 0.
+Function takes payload below, parses the `access_token` and looks for `iat` and `exp` keys to sum them. If they are not there it returns 0.
 
 API Payload
 
 ```json
 {
-  "auth_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjQxMzM5ODA3OTksImV4cCI6MzYwMH0.XzogySsPK2_KU4uceVR1rwwKa31_5Ur9zhqCaBYVzUw",
+  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjQxMzM5ODA3OTksImV4cCI6MzYwMH0.XzogySsPK2_KU4uceVR1rwwKa31_5Ur9zhqCaBYVzUw",
   "refresh_token": "..."
 }
 ```

--- a/packages/redux-api-auth-middleware/README.md
+++ b/packages/redux-api-auth-middleware/README.md
@@ -33,6 +33,7 @@ const authMiddleware = createAuthMiddleware({
   refreshConfig: {
     endpoint: '/refresh-token',
     failedAction: { type: 'LOGOUT' },
+    actionDefinition: ({ refreshToken, endpoint }) => refreshTokenAction(refreshToken, endpoint), //not required
   },
 });
 const middlewares = [authMiddleware, apiMiddleware];
@@ -65,7 +66,7 @@ import { setTokenAction } from '@tshio/redux-api-auth-middleware';
 import Component from './component';
 
 const mapDispatchToProps = dispatch => ({
-  onSignIn: ({authToken, refreshToken}) => dispatch(setTokenAction({ authToken, refreshToken }));
+  onSignIn: ({authToken, refreshToken}) => dispatch(setTokenAction({ auth_token: authToken, refresh_token: refreshToken, expires_in: 1555055916 }));
 }
 
 export default connect(
@@ -123,14 +124,15 @@ export default connect(
 
 ### Auth middleware
 
-| Key           | Option name  | Default value | Type          | Role                                                                |
-| ------------- | ------------ | ------------- | ------------- | ------------------------------------------------------------------- |
-| authConfig    | -            | -             | -             | Configuration for adding authorization headers                      |
-|               | header       | Authorization | `string`      | Name of the header passed to every request that needs authorization |
-|               | type         | Bearer        | `string`      | Type of the token                                                   |
-| refreshConfig | -            | -             | -             | Configuration for token refresh                                     |
-|               | endpoint     | undefined     | `string`      | API endpoint for token renewal                                      |
-|               | failedAction | undefined     | `ReduxAction` | Action that will be dispatched after failed token request           |
+| Key           | Option name      | Default value | Type          | Role                                                                           |
+| ------------- | ---------------- | ------------- | ------------- | ------------------------------------------------------------------------------ |
+| authConfig    | -                | -             | -             | Configuration for adding authorization headers                                 |
+|               | header           | Authorization | `string`      | Name of the header passed to every request that needs authorization            |
+|               | type             | Bearer        | `string`      | Type of the token                                                              |
+| refreshConfig | -                | -             | -             | Configuration for token refresh                                                |
+|               | endpoint         | undefined     | `string`      | API endpoint for token renewal                                                 |
+|               | failedAction     | undefined     | `ReduxAction` | Action that will be dispatched after failed token request                      |
+|               | actionDefinition | undefined     | `ReduxAction` | Function that will return RSAA Action that will be dispatched to refresh token |
 
 ### Auth reducer
 
@@ -142,14 +144,14 @@ There are two built in functions for calculating token expiration timestamp, one
 
 #### JWT Example
 
-Function takes payload below, parses the `authToken` and looks for `iat` and `exp` keys to sum them. If they are not there it returns 0.
+Function takes payload below, parses the `auth_token` and looks for `iat` and `exp` keys to sum them. If they are not there it returns 0.
 
 API Payload
 
 ```json
 {
-  "authToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjQxMzM5ODA3OTksImV4cCI6MzYwMH0.XzogySsPK2_KU4uceVR1rwwKa31_5Ur9zhqCaBYVzUw",
-  "refreshToken": "..."
+  "auth_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjQxMzM5ODA3OTksImV4cCI6MzYwMH0.XzogySsPK2_KU4uceVR1rwwKa31_5Ur9zhqCaBYVzUw",
+  "refresh_token": "..."
 }
 ```
 

--- a/packages/redux-api-auth-middleware/src/__tests__/auth.spec.js
+++ b/packages/redux-api-auth-middleware/src/__tests__/auth.spec.js
@@ -161,6 +161,7 @@ describe('Auth middleware', () => {
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjJ9.tbDepxpstvGdW8TC3G8zg4B6rUYAOvfzdceoH48wgRQ';
     expect(calculateJWTTokenExpirationDate({ auth_token: authToken })).toEqual(4426644036);
     expect(calculateJWTTokenExpirationDate({ auth_token: badToken })).toEqual(0);
+    expect(calculateJWTTokenExpirationDate({ auth_token: 'bad' })).toEqual(0);
     expect(calculateJWTTokenExpirationDate('foo')).toEqual(0);
     expect(calculateJWTTokenExpirationDate()).toEqual(0);
   });

--- a/packages/redux-api-auth-middleware/src/__tests__/auth.spec.js
+++ b/packages/redux-api-auth-middleware/src/__tests__/auth.spec.js
@@ -62,9 +62,9 @@ describe('Auth middleware', () => {
   it('should create an action to set the token', () => {
     const expectedAction = {
       type: SET_TOKEN,
-      payload: { authToken, refreshToken },
+      payload: { auth_token: authToken, refresh_token: refreshToken },
     };
-    expect(setTokenAction({ authToken, refreshToken })).toEqual(expectedAction);
+    expect(setTokenAction({ auth_token: authToken, refresh_token: refreshToken })).toEqual(expectedAction);
   });
 
   it('should create an action to clear the token', () => {
@@ -91,10 +91,12 @@ describe('Auth middleware', () => {
   });
 
   it('should handle set token action', () => {
-    expect(authReducer({}, { type: SET_TOKEN, payload: { authToken, refreshToken } })).toEqual({
+    expect(
+      authReducer({}, { type: SET_TOKEN, payload: { auth_token: authToken, refresh_token: refreshToken } }),
+    ).toEqual({
       authToken,
       refreshToken,
-      expires: calculateJWTTokenExpirationDate({ authToken }),
+      expires: calculateJWTTokenExpirationDate({ auth_token: authToken }),
     });
   });
 
@@ -107,10 +109,12 @@ describe('Auth middleware', () => {
   });
 
   it('should handle refresh token success action', () => {
-    expect(authReducer({}, { type: REFRESH_TOKEN_SUCCESS, payload: { authToken, refreshToken } })).toEqual({
+    expect(
+      authReducer({}, { type: REFRESH_TOKEN_SUCCESS, payload: { auth_token: authToken, refresh_token: refreshToken } }),
+    ).toEqual({
       authToken,
       refreshToken,
-      expires: calculateJWTTokenExpirationDate({ authToken }),
+      expires: calculateJWTTokenExpirationDate({ auth_token: authToken }),
     });
   });
 
@@ -142,21 +146,21 @@ describe('Auth middleware', () => {
 
   it('should calculate JWT token expiration properly', () => {
     expect(isTokenExpired()).toBeTruthy();
-    expect(isTokenExpired(calculateJWTTokenExpirationDate({ authToken }))).toBeFalsy();
-    expect(isTokenExpired(calculateJWTTokenExpirationDate({ authToken: expiredAuthToken }))).toBeTruthy();
+    expect(isTokenExpired(calculateJWTTokenExpirationDate({ auth_token: authToken }))).toBeFalsy();
+    expect(isTokenExpired(calculateJWTTokenExpirationDate({ auth_token: expiredAuthToken }))).toBeTruthy();
     expect(isTokenExpired('Not Valid Token')).toBeFalsy();
   });
 
   it('should parse JWT', () => {
-    expect(parseJWTPayload(authToken)).toEqual({ exp: 3600, iat: 4133980799 });
+    expect(parseJWTPayload(authToken)).toEqual({ exp: 4426644036, iat: 1555053636, iss: 'test', sub: '', aud: '' });
     expect(parseJWTPayload()).toEqual(null);
   });
 
   it('should calculate JWT expiration date', () => {
     const badToken =
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjJ9.tbDepxpstvGdW8TC3G8zg4B6rUYAOvfzdceoH48wgRQ';
-    expect(calculateJWTTokenExpirationDate({ authToken })).toEqual(4133980799 + 3600);
-    expect(calculateJWTTokenExpirationDate({ authToken: badToken })).toEqual(0);
+    expect(calculateJWTTokenExpirationDate({ auth_token: authToken })).toEqual(4426644036);
+    expect(calculateJWTTokenExpirationDate({ auth_token: badToken })).toEqual(0);
     expect(calculateJWTTokenExpirationDate('foo')).toEqual(0);
     expect(calculateJWTTokenExpirationDate()).toEqual(0);
   });
@@ -245,8 +249,8 @@ describe('Auth middleware', () => {
       },
     };
     fetchMock.mock(refreshEndpoint, {
-      authToken,
-      refreshToken,
+      auth_token: authToken,
+      refresh_token: refreshToken,
     });
     fetchMock.mock(apiEndpoint, 200);
     await store.dispatch(action);
@@ -278,8 +282,8 @@ describe('Auth middleware', () => {
       },
     };
     fetchMock.mock(refreshEndpoint, {
-      authToken,
-      refreshToken,
+      auth_token: authToken,
+      refresh_token: refreshToken,
     });
     fetchMock.mock(apiEndpoint, 200);
     await store.dispatch(action);

--- a/packages/redux-api-auth-middleware/src/__tests__/const.js
+++ b/packages/redux-api-auth-middleware/src/__tests__/const.js
@@ -1,5 +1,5 @@
 export const authToken =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjQxMzM5ODA3OTksImV4cCI6MzYwMH0.XzogySsPK2_KU4uceVR1rwwKa31_5Ur9zhqCaBYVzUw';
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNTU1MDUzNjM2LCJleHAiOjQ0MjY2NDQwMzYsImF1ZCI6IiIsInN1YiI6IiJ9.-kIuG3rnBOBxjwy2go1e6wag8I3oM_9EYFD9ROD2LvQ';
 
 export const expiredAuthToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjg2NDAwLCJpYXQiOjE1MTYyMzkwMjJ9.0_snudLchIspTQgFvH2fg6c33WxQyxlEtLY84Kfj5EE';

--- a/packages/redux-api-auth-middleware/src/__tests__/const.js
+++ b/packages/redux-api-auth-middleware/src/__tests__/const.js
@@ -1,4 +1,4 @@
-export const authToken =
+export const accessToken =
   'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZXN0IiwiaWF0IjoxNTU1MDUzNjM2LCJleHAiOjQ0MjY2NDQwMzYsImF1ZCI6IiIsInN1YiI6IiJ9.-kIuG3rnBOBxjwy2go1e6wag8I3oM_9EYFD9ROD2LvQ';
 
 export const expiredAuthToken =

--- a/packages/redux-api-auth-middleware/src/auth.middleware.js
+++ b/packages/redux-api-auth-middleware/src/auth.middleware.js
@@ -31,7 +31,7 @@ export default function({
               typeof action[RSAA].headers !== 'function'
                 ? {
                     ...action[RSAA].headers,
-                    [authConfig.header]: `${authConfig.type} ${store.getState().auth.authToken}`,
+                    [authConfig.header]: `${authConfig.type} ${store.getState().auth.accessToken}`,
                   }
                 : action[RSAA].headers,
           },
@@ -44,9 +44,9 @@ export default function({
           return next(action);
         }
 
-        const { authToken, refreshToken, expires } = store.getState().auth;
+        const { accessToken, refreshToken, expires } = store.getState().auth;
 
-        if (authToken) {
+        if (accessToken) {
           if (refreshConfig && isTokenExpired(expires)) {
             if (!refreshPromise) {
               refreshPromise = store

--- a/packages/redux-api-auth-middleware/src/auth.middleware.js
+++ b/packages/redux-api-auth-middleware/src/auth.middleware.js
@@ -50,7 +50,11 @@ export default function({
           if (refreshConfig && isTokenExpired(expires)) {
             if (!refreshPromise) {
               refreshPromise = store
-                .dispatch(refreshTokenAction({ refreshToken: refreshToken, endpoint: refreshConfig.endpoint }))
+                .dispatch(
+                  refreshConfig.actionDefinition
+                    ? refreshConfig.actionDefinition({ refreshToken: refreshToken, endpoint: refreshConfig.endpoint })
+                    : refreshTokenAction({ refreshToken: refreshToken, endpoint: refreshConfig.endpoint }),
+                )
                 .then(apiCall => {
                   refreshPromise = null;
                   return apiCall;

--- a/packages/redux-api-auth-middleware/src/helpers.js
+++ b/packages/redux-api-auth-middleware/src/helpers.js
@@ -3,7 +3,7 @@
 import type { AnyObject } from './types';
 
 export function timestampNow() {
-  return Math.floor(+new Date() / 1000); // equal to timestampNow()
+  return Math.floor(+new Date() / 1000);
 }
 
 export function parseJWTPayload(token: string): AnyObject | null {
@@ -16,11 +16,17 @@ export function parseJWTPayload(token: string): AnyObject | null {
 }
 
 export function calculateJWTTokenExpirationDate(payload: AnyObject): number {
-  if (!payload || !payload.authToken) return 0;
-  const token = parseJWTPayload(payload.authToken);
-  if (!token) return 0;
-  const { iat, exp } = token;
-  return iat && exp ? Number(iat) + Number(exp) : 0;
+  if (!payload || !payload.auth_token) {
+    return 0;
+  }
+
+  const token = parseJWTPayload(payload.auth_token);
+
+  if (!token) {
+    return 0;
+  }
+
+  return token.exp ? Number(token.exp) : 0;
 }
 
 export function calculateOauthTokenExpirationDate(payload: AnyObject): number {

--- a/packages/redux-api-auth-middleware/src/helpers.js
+++ b/packages/redux-api-auth-middleware/src/helpers.js
@@ -16,11 +16,11 @@ export function parseJWTPayload(token: string): AnyObject | null {
 }
 
 export function calculateJWTTokenExpirationDate(payload: AnyObject): number {
-  if (!payload || !payload.auth_token) {
+  if (!payload || !payload.access_token) {
     return 0;
   }
 
-  const token = parseJWTPayload(payload.auth_token);
+  const token = parseJWTPayload(payload.access_token);
 
   if (!token) {
     return 0;

--- a/packages/redux-api-auth-middleware/src/store/actions.js
+++ b/packages/redux-api-auth-middleware/src/store/actions.js
@@ -2,10 +2,18 @@ import { RSAA } from 'redux-api-middleware';
 import { CLEAR_TOKEN, REFRESH_TOKEN_FAILURE, REFRESH_TOKEN_REQUEST, REFRESH_TOKEN_SUCCESS, SET_TOKEN } from './types';
 import type { Action } from '../types';
 
-export function setTokenAction({ authToken, refreshToken }: { authToken: string, refreshToken: string }): Action {
+export function setTokenAction({
+  auth_token,
+  refresh_token,
+  expires_in,
+}: {
+  auth_token: string,
+  refresh_token?: string,
+  expires_in?: number,
+}): Action {
   return {
     type: SET_TOKEN,
-    payload: { authToken, refreshToken },
+    payload: { auth_token, refresh_token, expires_in },
   };
 }
 

--- a/packages/redux-api-auth-middleware/src/store/actions.js
+++ b/packages/redux-api-auth-middleware/src/store/actions.js
@@ -3,17 +3,17 @@ import { CLEAR_TOKEN, REFRESH_TOKEN_FAILURE, REFRESH_TOKEN_REQUEST, REFRESH_TOKE
 import type { Action } from '../types';
 
 export function setTokenAction({
-  auth_token,
+  access_token,
   refresh_token,
   expires_in,
 }: {
-  auth_token: string,
+  access_token: string,
   refresh_token?: string,
   expires_in?: number,
 }): Action {
   return {
     type: SET_TOKEN,
-    payload: { auth_token, refresh_token, expires_in },
+    payload: { access_token, refresh_token, expires_in },
   };
 }
 

--- a/packages/redux-api-auth-middleware/src/store/reducer.js
+++ b/packages/redux-api-auth-middleware/src/store/reducer.js
@@ -3,7 +3,7 @@ import { CLEAR_TOKEN, REFRESH_TOKEN_FAILURE, REFRESH_TOKEN_SUCCESS, SET_TOKEN } 
 import type { GetExpirationTimestamp, SetTokenAction, State } from '../types';
 
 export const initialState: State = {
-  authToken: null,
+  accessToken: null,
   refreshToken: null,
   expires: 0,
 };
@@ -16,14 +16,14 @@ export default function({
       case SET_TOKEN:
         return {
           ...state,
-          authToken: action.payload?.auth_token,
+          accessToken: action.payload?.access_token,
           refreshToken: action.payload?.refresh_token,
           expires: getExpirationTimestamp(action.payload),
         };
       case REFRESH_TOKEN_SUCCESS:
         return {
           ...state,
-          authToken: action.payload?.auth_token,
+          accessToken: action.payload?.access_token,
           refreshToken: action.payload?.refresh_token,
           expires: getExpirationTimestamp(action.payload),
         };

--- a/packages/redux-api-auth-middleware/src/store/reducer.js
+++ b/packages/redux-api-auth-middleware/src/store/reducer.js
@@ -16,15 +16,15 @@ export default function({
       case SET_TOKEN:
         return {
           ...state,
-          authToken: action.payload?.authToken,
-          refreshToken: action.payload?.refreshToken,
+          authToken: action.payload?.auth_token,
+          refreshToken: action.payload?.refresh_token,
           expires: getExpirationTimestamp(action.payload),
         };
       case REFRESH_TOKEN_SUCCESS:
         return {
           ...state,
-          authToken: action.payload?.authToken,
-          refreshToken: action.payload?.refreshToken,
+          authToken: action.payload?.auth_token,
+          refreshToken: action.payload?.refresh_token,
           expires: getExpirationTimestamp(action.payload),
         };
       case CLEAR_TOKEN:

--- a/packages/redux-api-auth-middleware/src/types.js.flow
+++ b/packages/redux-api-auth-middleware/src/types.js.flow
@@ -29,6 +29,7 @@ export type AuthConfig = {
 export type RefreshConfig = {
   endpoint: string,
   failedAction: AnyAction,
+  actionDefinition: ({refreshToken: string, endpoint: string}) => Object,
 };
 
 export type SetTokenAction = {
@@ -37,8 +38,8 @@ export type SetTokenAction = {
 };
 
 export type TokenPayload = {
-  authToken: ?string,
-  refreshToken: ?string,
+  auth_token: ?string,
+  refresh_token: ?string,
   expires_in?: number
 };
 

--- a/packages/redux-api-auth-middleware/src/types.js.flow
+++ b/packages/redux-api-auth-middleware/src/types.js.flow
@@ -7,7 +7,7 @@ export type AnyObject = {
 };
 
 export type State = {
-  authToken: ?string,
+  accessToken: ?string,
   refreshToken: ?string,
   expirationDate: ?number,
 };
@@ -38,7 +38,7 @@ export type SetTokenAction = {
 };
 
 export type TokenPayload = {
-  auth_token: ?string,
+  access_token: ?string,
   refresh_token: ?string,
   expires_in?: number
 };

--- a/packages/redux-api-auth-middleware/typings/index.d.ts
+++ b/packages/redux-api-auth-middleware/typings/index.d.ts
@@ -10,9 +10,12 @@ type AuthConfig = {
   type: string;
 };
 
+type refreshTokenActionParams = { refreshToken: string; endpoint: string };
+
 type RefreshConfig = {
   endpoint: string;
   failedAction: AnyAction;
+  actionDefinition?: (params: refreshTokenActionParams) => object;
 };
 
 type AnyObject = {
@@ -26,8 +29,9 @@ type ReducerOptions = {
 };
 
 type TokenActionType = {
-  authToken: string;
-  refreshToken?: string;
+  auth_token: string;
+  refresh_token?: string;
+  expires_in?: number;
 };
 
 type AuthState = {
@@ -43,3 +47,17 @@ export function clearTokenAction(): AnyAction;
 export function createAuthMiddleware(options: MiddlewareConfig): Middleware;
 
 export function createAuthReducer(options?: ReducerOptions): Reducer<AuthState, AnyAction>;
+
+export function calculateOauthTokenExpirationDate(response: AnyObject): number;
+
+export function calculateJWTTokenExpirationDate(response: AnyObject): number;
+
+export const SET_TOKEN: string;
+
+export const CLEAR_TOKEN: string;
+
+export const REFRESH_TOKEN_REQUEST: string;
+
+export const REFRESH_TOKEN_FAILURE: string;
+
+export const REFRESH_TOKEN_SUCCESS: string;

--- a/packages/redux-api-auth-middleware/typings/index.d.ts
+++ b/packages/redux-api-auth-middleware/typings/index.d.ts
@@ -29,13 +29,13 @@ type ReducerOptions = {
 };
 
 type TokenActionType = {
-  auth_token: string;
+  access_token: string;
   refresh_token?: string;
   expires_in?: number;
 };
 
 type AuthState = {
-  authToken: null | string;
+  accessToken: null | string;
   refreshToken: null | string;
   expires: number;
 };


### PR DESCRIPTION
- Adjust redux-api-auth-middleware to standard oAuth response (replace camelcase with underscore in all places), 
- Allow to set own refresh token RSAA action instead of built-in one
- Fix setTokenAction to allow define initial expiresIn timestamp
- Fix TS typings
- Fix calculating JWT and OAUTH token expiration dates (according to spec)